### PR TITLE
DECREASE TypeScript compiler target to es2015

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Decreased target build to es2015.
+
 ## 1.2.1
 
 - Fixed Travis configuration to publish and create documentation on release tags.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     ],
     "moduleResolution": "node",
     "module": "esnext",
-    "target": "es2017",
+    "target": "es2015",
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",


### PR DESCRIPTION
Due to unsupported JS features in this library's distributive, some builds which use UglifyJS are failed.