### PR TITLE
Update ChoicesJS library

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": [ "@babel/plugin-syntax-dynamic-import" ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.3.0
+
+- Updated StencilJS core to v0.18.1.
+- Updated ChoicesJS to v7.0.0.
+  - `regexFilter` config has been replaced with `addItemFilterFn` function.
+  - `toggleDropdown` method has been removed.
+  - `clearChoices` method has been added.
+- Updated example with new options.
+- Updated documentation with example of framework integration.
+
 ## 1.2.1
 
 - Fixed Travis configuration to publish and create documentation on release tags.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The library is based on [ChoicesJS][choicesjs], but it is not bundle along with 
 This dependency can be added to the bundle as external library, or it can just be added to the page via GitHub script:
 
 ```html
-<script src="https://rawgit.com/jshjohnson/Choices/v4.1.3/public/assets/scripts/choices.js"></script>
+<script src="https://rawgit.com/jshjohnson/Choices/v7.0.0/public/assets/scripts/choices.js"></script>
 ```
 
 ## Installation and running
@@ -94,6 +94,64 @@ Some of this component properties must be set via JavaScript (non primitive type
   ];
 
   element.disable();
+</script>
+```
+
+### Framework integration
+
+It is a good decision to create a wrapper of the Web Component to be ready to use by the application framework.
+
+The wrapper has to cover at least:
+
+- Properties:
+  - `type`: type of selector (see values in configuration section).
+  - `choices`: values to display in the selector.
+  - `name?`: name of the element (recommended).
+  - Other Web Component properties can be fixed or set dynamically.
+- Listeners:
+  - Changes on `choices` property to update the values of `choices` in the Web Component:
+  - `change` event of the Web Component to be able to propagate it.
+
+#### Example for VueJS framework
+
+```javascript
+// Loading ChoicesJS library and ChoicesJS Stencil Web Component
+import 'expose-loader?Choices!choices.js';
+import { defineCustomElements } from 'choicesjs-stencil/dist/loader';
+
+defineCustomElements(window);
+
+// VueJS component
+<template>
+  <choicesjs-stencil class="choicesjs-stencil"
+      :type="type"
+      :name="name"
+      ...
+  />
+</template>
+
+<script>
+export default {
+  props: [ 'type', 'name', 'choices' ],
+  watch: {
+    choices: {
+      immediate: true,
+      handler(newChoices, oldChoices) {
+        const select = this.$el;
+
+        if (select && oldChoices !== newChoices) {
+          select.choices = newChoices;
+        }
+      }
+    }
+  },
+  mounted() {
+    const select = this.$el;
+
+    select.choices = this.choices;
+    select.addEventListener('change', () => this.$emit('change'));
+  }
+};
 </script>
 ```
 

--- a/index.html
+++ b/index.html
@@ -339,7 +339,7 @@
               <label for="addItemFilterFn">
                 addItemFilterFn(value) {
               </label>
-              <span class="description" data-toggle="tooltip" title="Function to that will need to pass for a user to successfully add an item.">
+              <span class="description" data-toggle="tooltip" title="The function that will need to pass for a user to successfully add an item.">
                 <span class="glyphicon glyphicon glyphicon-question-sign"></span>
               </span>
               <textarea class="form-control textarea--vertical" name="addItemFilterFn" rows="2">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/js/bootstrap.min.js"></script>
-    <script src="https://rawgit.com/jshjohnson/Choices/v4.1.3/public/assets/scripts/choices.js"></script>
+    <script src="https://rawgit.com/jshjohnson/Choices/v7.0.0/public/assets/scripts/choices.js"></script>
     <script src="dist/choicesjsstencil.js"></script>
     <style>
       html {
@@ -335,18 +335,17 @@
               </span>
               <input type="text" class="form-control" name="searchFields" value="[&quot;label&quot;, &quot;value&quot;]">
             </div>
-            <div class="form-group type type--text">
-              <label for="regexFilter">
-                Regex Filter
+            <div class="form-group">
+              <label for="addItemFilterFn">
+                addItemFilterFn(value) {
               </label>
-              <span class="description" data-toggle="tooltip" title="A filter that will need to pass for a user to successfully add an item.">
+              <span class="description" data-toggle="tooltip" title="Function to that will need to pass for a user to successfully add an item.">
                 <span class="glyphicon glyphicon glyphicon-question-sign"></span>
               </span>
-              <div class="input-group">
-                <span class="input-group-addon">/</span>
-                <input type="text" class="form-control" name="regexFilter">
-                <span class="input-group-addon">/</span>
-              </div>
+              <textarea class="form-control textarea--vertical" name="addItemFilterFn" rows="2">
+return /^[^\s]+$/.test(value);
+              </textarea>
+              <label for="addItemFilterFn">}</label>
             </div>
             <div class="form-group type type--single type--multiple">
               <label for="position">
@@ -483,7 +482,9 @@
               <span class="description" data-toggle="tooltip" title="Function to run once Choices initialises.">
                 <span class="glyphicon glyphicon glyphicon-question-sign"></span>
               </span>
-              <textarea class="form-control textarea--vertical" name="callbackOnInit" rows="2"></textarea>
+              <textarea class="form-control textarea--vertical" name="callbackOnInit" rows="2">
+console.info('ChoicesJS Stencil Web Component ready!');
+              </textarea>
               <label for="callbackOnInit">}</label>
             </div>
             <div class="form-group">
@@ -493,10 +494,12 @@
               <span class="description" data-toggle="tooltip" title="Function to run on template creation. Through this callback it is possible to provide custom templates for the various components of Choices (see terminology). For Choices to work with custom templates, it is important you maintain the various data attributes defined in the reference link below.">
                 <span class="glyphicon glyphicon glyphicon-question-sign"></span>
               </span>
-              <textarea class="form-control textarea--vertical" name="callbackOnCreateTemplates" rows="2"></textarea>
+              <textarea class="form-control textarea--vertical" name="callbackOnCreateTemplates" rows="2">
+return template;
+              </textarea>
               <label for="callbackOnCreateTemplates">}</label>
               <br/>
-              <a href="https://github.com/jshjohnson/Choices/blob/67f29c286aa21d88847adfcd6304dc7d068dc01f/assets/scripts/src/choices.js#L1993-L2067">
+              <a href="https://github.com/jshjohnson/Choices/blob/v7.0.0/public/assets/scripts/choices.js#L713-L788" target="_blank">
                 Templates reference
               </a>
             </div>
@@ -520,7 +523,11 @@ return a.label.localeCompare(b.label);
       <div class="container">
         <div class="row">
           <div class="col-md-12">
-            <p class="text-center pad-top">See full documentation in <a href="https://www.npmjs.com/package/choices.js">choices.js</a> npm package.</p>
+            <p class="text-center pad-top">
+              See full documentation in
+              <a href="https://www.npmjs.com/package/choices.js/v/7.0.0" target="_blank">choices.js</a>
+              npm package.
+            </p>
           </div>
         </div>
       </div>
@@ -603,7 +610,9 @@ return a.label.localeCompare(b.label);
               <h4 class="modal-title">Search options</h4>
           </div>
           <div class="modal-body">
-            <h5 class="text-center pad-bottom">See full Fuse documentation in <a href="https://github.com/krisk/Fuse/tree/v2.7.4#options">GitHub</a>.</h5>
+            <h5 class="text-center pad-bottom">
+              See full Fuse documentation in <a href="https://fusejs.io/" target="_blank">GitHub</a>.
+            </h5>
             <form name="custom-search-form">
               <div class="form-group">
                 <div class="row">
@@ -789,7 +798,9 @@ return a.label.localeCompare(b.label);
             choices: jsonParser,
             items: jsonParser,
             searchFields: jsonParser,
-            regexFilter: regexParser(),
+            addItemFilterFn: function(value) {
+              return new Function('value', value.trim());
+            },
             renderChoiceLimit: Number,
             maxItemCount: Number,
             searchFloor: Number,

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,14 +20,14 @@
       }
     },
     "@stencil/core": {
-      "version": "0.17.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@stencil/core/-/core-0.17.0.tgz",
-      "integrity": "sha1-35ZyxAQi6I8kdMBUbFEG9T0kXhY=",
+      "version": "0.18.1",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@stencil/core/-/core-0.18.1.tgz",
+      "integrity": "sha1-7df/KXUcTTdxTl47DOMjbUg3Q6A=",
       "dev": true,
       "requires": {
         "chokidar": "2.0.3",
         "jsdom": "11.11.0",
-        "typescript": "3.2.2"
+        "typescript": "3.3.3"
       }
     },
     "@stencil/sass": {
@@ -46,15 +46,15 @@
       "dev": true
     },
     "@types/events": {
-      "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
-      "integrity": "sha512-KEIlhXnIutzKwRbQkGWb/I4HFqBuUykAdHgDED6xqwXJfONCjF5VoE0cXEiurh3XauygxzeDzgtXUqvLkxFzzA==",
+      "version": "3.0.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
-      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "version": "5.0.5",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/fs-extra/-/fs-extra-5.0.5.tgz",
+      "integrity": "sha1-CA2Qp5Lz+ixVWetEvY74QKrpEEs=",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -62,8 +62,8 @@
     },
     "@types/glob": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
       "dev": true,
       "requires": {
         "@types/events": "*",
@@ -72,15 +72,18 @@
       }
     },
     "@types/handlebars": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
-      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha1-P8zpv4j4X+c9yTIkCrP7aCxiSFA=",
+      "dev": true,
+      "requires": {
+        "handlebars": "*"
+      }
     },
     "@types/highlight.js": {
       "version": "9.12.3",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+      "integrity": "sha1-tnLPqsJcu8Y0oP2SxRX2b6oY28o=",
       "dev": true
     },
     "@types/jest": {
@@ -90,33 +93,33 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.118",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.118.tgz",
-      "integrity": "sha512-iiJbKLZbhSa6FYRip/9ZDX6HXhayXLDGY2Fqws9cOkEQ6XeKfaxB0sC541mowZJueYyMnVUmmG+al5/4fCDrgw==",
+      "version": "4.14.123",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/lodash/-/lodash-4.14.123.tgz",
+      "integrity": "sha1-Ob5dIRR4yN072umO51u37+Sr/k0=",
       "dev": true
     },
     "@types/marked": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/marked/-/marked-0.4.2.tgz",
+      "integrity": "sha1-ZKieU+o39hzA8+4XMsVVwtv2RS8=",
       "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
       "dev": true
     },
     "@types/node": {
-      "version": "10.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.12.tgz",
-      "integrity": "sha512-Pr+6JRiKkfsFvmU/LK68oBRCQeEg36TyAbPhc2xpez24OOZZCuoIhWGTd39VZy6nGafSbxzGouFPTFD/rR1A0A==",
+      "version": "11.13.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/node/-/node-11.13.0.tgz",
+      "integrity": "sha1-sN+Nbvm1ABsr46lNkJzjwpqA+eE=",
       "dev": true
     },
     "@types/shelljs": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.0.tgz",
-      "integrity": "sha512-vs1hCC8RxLHRu2bwumNyYRNrU3o8BtZhLysH5A4I98iYmA2APl6R3uNQb5ihl+WiwH0xdC9LLO+vRrXLs/Kyxg==",
+      "version": "0.8.4",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@types/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha1-uQPkGtXlGVt9XjTTzTPJS9vQeJU=",
       "dev": true,
       "requires": {
         "@types/glob": "*",
@@ -1817,8 +1820,8 @@
     },
     "fs-extra": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/fs-extra/-/fs-extra-7.0.1.tgz",
+      "integrity": "sha1-TxicRKoSO4lfcigE9V6iPq3DSOk=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -1833,9 +1836,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha1-SFG2ZKN4PlIAOzxm6w7uEHSTOqQ=",
       "optional": true,
       "requires": {
         "nan": "^2.9.2",
@@ -1857,7 +1860,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1878,7 +1881,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "optional": true
         },
@@ -1908,7 +1911,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "optional": true
         },
@@ -1951,7 +1954,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -1969,11 +1972,11 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -2026,15 +2029,15 @@
           "bundled": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -2054,7 +2057,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -2064,17 +2067,17 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -2090,12 +2093,12 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "optional": true,
           "requires": {
@@ -2160,11 +2163,11 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -2192,15 +2195,15 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true
         },
         "safer-buffer": {
@@ -2214,7 +2217,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "optional": true
         },
@@ -2258,16 +2261,16 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -2277,11 +2280,11 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -2289,7 +2292,7 @@
           "bundled": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true
         }
       }
@@ -2624,9 +2627,9 @@
       }
     },
     "highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+      "version": "9.15.6",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/highlight.js/-/highlight.js-9.15.6.tgz",
+      "integrity": "sha1-ctTY13nsBmr5oXyxQ2DD3vCqV8Q=",
       "dev": true
     },
     "hoek": {
@@ -2733,9 +2736,9 @@
       "dev": true
     },
     "interpret": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "version": "1.2.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha1-1QYaYiS+WOgIOYX1AU2EQ1lXYpY=",
       "dev": true
     },
     "invariant": {
@@ -3600,49 +3603,43 @@
       "dev": true
     },
     "jest-dot-reporter": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/jest-dot-reporter/-/jest-dot-reporter-1.0.3.tgz",
-      "integrity": "sha512-c4fz3dRh7qfoaF2Lwp1yWUvKK65hp4g9aVA6mDCsUTS7wZfYkI4NRxHsXA0P4dOWCtdTfZoXBPW/WP8nAA0eYA==",
+      "version": "1.0.7",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/jest-dot-reporter/-/jest-dot-reporter-1.0.7.tgz",
+      "integrity": "sha1-84a/yNHtM6cnMtLAQEp1kZF/Oz0=",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0",
-        "moment": "2.18.1",
+        "chalk": "2.4.1",
+        "moment": "2.22.2",
         "progress": "2.0.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.4.1",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.1.0",
+            "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
-            "supports-color": "^4.0.0"
+            "supports-color": "^5.3.0"
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.5.0",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4953,8 +4950,8 @@
     },
     "marked": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/marked/-/marked-0.4.0.tgz",
+      "integrity": "sha1-mtLCp6F5HxCoUuARL3e1cdzhDGY=",
       "dev": true
     },
     "matched": {
@@ -5120,9 +5117,9 @@
       }
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8=",
+      "version": "2.22.2",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
       "dev": true
     },
     "ms": {
@@ -5771,7 +5768,7 @@
     },
     "progress": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
@@ -5873,7 +5870,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -6067,12 +6064,12 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "rsvp": {
@@ -6219,8 +6216,8 @@
     },
     "shelljs": {
       "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha1-p/MxlSDr8J7oEnWyNorbKGZZsJc=",
       "dev": true,
       "requires": {
         "glob": "^7.0.0",
@@ -6954,14 +6951,14 @@
     },
     "tslib": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
       "dev": true
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.15.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/tslint/-/tslint-5.15.0.tgz",
+      "integrity": "sha1-b/sYCYbWOvoeUx/rKhNNv5YeJ9M=",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -6970,27 +6967,28 @@
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
           "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -6998,19 +6996,35 @@
             "supports-color": "^5.3.0"
           }
         },
-        "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+        "esprima": {
+          "version": "4.0.1",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/esprima/-/esprima-4.0.1.tgz",
+          "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.13.0",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-3.13.0.tgz",
+          "integrity": "sha1-OO5xeKwO6iyX/22W//SxjH2M+Y4=",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.10.0",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha1-O9qur0XMB/N1ZW39LlTtCBCxAbo=",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
           }
         },
         "supports-color": {
           "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -7054,8 +7068,8 @@
     },
     "tsutils": {
       "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/tsutils/-/tsutils-2.29.0.tgz",
+      "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -7086,9 +7100,9 @@
       }
     },
     "typedoc": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.12.0.tgz",
-      "integrity": "sha512-dsdlaYZ7Je8JC+jQ3j2Iroe4uyD0GhqzADNUVyBRgLuytQDP/g0dPkAw5PdM/4drnmmJjRzSWW97FkKo+ITqQg==",
+      "version": "0.14.2",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/typedoc/-/typedoc-0.14.2.tgz",
+      "integrity": "sha1-dp9Ff0+eS9uLXzsXfIa2ox2MPcM=",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^5.0.3",
@@ -7100,34 +7114,34 @@
         "@types/shelljs": "^0.8.0",
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
-        "highlight.js": "^9.0.0",
+        "highlight.js": "^9.13.1",
         "lodash": "^4.17.10",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",
         "shelljs": "^0.8.2",
         "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.0.x"
+        "typescript": "3.2.x"
       },
       "dependencies": {
         "typescript": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
-          "integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg==",
+          "version": "3.2.4",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/typescript/-/typescript-3.2.4.tgz",
+          "integrity": "sha1-xYXLlSkSJj2RW0YnJs4kS6UQ7z0=",
           "dev": true
         }
       }
     },
     "typedoc-default-themes": {
       "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
       "dev": true
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha1-/oEBxGqhI/g1NSPr3PVzDCrkk+U=",
+      "version": "3.3.3",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/typescript/-/typescript-3.3.3.tgz",
+      "integrity": "sha1-8WV/x9qifhqJMHWKzpro2jFAMiE=",
       "dev": true
     },
     "uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,33 @@
 {
   "name": "choicesjs-stencil",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/helper-plugin-utils": {
+      "version": "7.0.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
+      "integrity": "sha1-u7P77phmHFaQNCN8wDlnupm08lA=",
+      "dev": true
+    },
+    "@babel/plugin-syntax-dynamic-import": {
+      "version": "7.2.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
+      "integrity": "sha1-acFZ/69JmBIhYa2OvF5tH1XfhhI=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
     "@stencil/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-ijRanqHwJlnLlEs8iMA7mn3d1Df0lOPXDqJTBNTwNCF1rxjh9/3aDgYFS/h5COS26bz1qmbmtaN2omaQmI9S/Q==",
+      "version": "0.17.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/@stencil/core/-/core-0.17.0.tgz",
+      "integrity": "sha1-35ZyxAQi6I8kdMBUbFEG9T0kXhY=",
       "dev": true,
       "requires": {
         "chokidar": "2.0.3",
         "jsdom": "11.11.0",
-        "typescript": "~3.1.6"
+        "typescript": "3.2.2"
       }
     },
     "@stencil/sass": {
@@ -122,14 +137,14 @@
     },
     "acorn": {
       "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
-      "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn/-/acorn-5.7.3.tgz",
+      "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
       "dev": true
     },
     "acorn-globals": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-      "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn-globals/-/acorn-globals-4.3.0.tgz",
+      "integrity": "sha1-47b42jwVUqla5idXH33Wkju1QQM=",
       "dev": true,
       "requires": {
         "acorn": "^6.0.1",
@@ -137,17 +152,17 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-          "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+          "version": "6.1.1",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha1-fSWuBbuK0fm2mRCOEJTs14hK3B8=",
           "dev": true
         }
       }
     },
     "acorn-walk": {
       "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-      "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "integrity": "sha1-02O2b1+sXwGP+cOh57b44xDMORM=",
       "dev": true
     },
     "ajv": {
@@ -343,8 +358,8 @@
     },
     "async-limiter": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
       "dev": true
     },
     "asynckit": {
@@ -651,9 +666,9 @@
       }
     },
     "binary-extensions": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+      "version": "1.13.1",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha1-WYr+VHVbKGilMw0q/51Ou1Mgm2U=",
       "dev": true
     },
     "block-stream": {
@@ -712,8 +727,8 @@
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
-      "integrity": "sha512-bRFnI4NnjO6cnyLmOV/7PVoDEMJChlcfN0z4s1YMBY989/SvlfMI1lgCnkFUs53e9gQF+w7qu7XdllSTiSl8Aw==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
       "dev": true
     },
     "browser-resolve": {
@@ -823,8 +838,8 @@
     },
     "chokidar": {
       "version": "2.0.3",
-      "resolved": "http://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-      "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/chokidar/-/chokidar-2.0.3.tgz",
+      "integrity": "sha1-3L1PbLsqVbR5m6ioQKxSfl9LEXY=",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -1083,8 +1098,8 @@
     },
     "cssstyle": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
-      "integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/cssstyle/-/cssstyle-0.3.1.tgz",
+      "integrity": "sha1-bam0z/G8XXFubl/o4E/LG1Ckmt8=",
       "dev": true,
       "requires": {
         "cssom": "0.3.x"
@@ -1116,8 +1131,8 @@
     },
     "data-urls": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
@@ -1127,14 +1142,14 @@
       "dependencies": {
         "abab": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
-          "integrity": "sha512-sY5AXXVZv4Y1VACTtR11UJCPHHudgY5i26Qj5TypE6DKlIApbwb5uqhXcJ5UUGbvZNRh7EeIoW+LrJumBsKp7w==",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/abab/-/abab-2.0.0.tgz",
+          "integrity": "sha1-q6CrTF7uLUx500h9hUUPsjduuw8=",
           "dev": true
         },
         "whatwg-url": {
           "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.0.0.tgz",
-          "integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
           "dev": true,
           "requires": {
             "lodash.sortby": "^4.7.0",
@@ -1280,8 +1295,8 @@
     },
     "domexception": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
       "dev": true,
       "requires": {
         "webidl-conversions": "^4.0.2"
@@ -2407,7 +2422,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
@@ -2417,7 +2432,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -2784,7 +2799,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -2877,7 +2892,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
@@ -2900,9 +2915,9 @@
       }
     },
     "is-glob": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-      "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+      "version": "4.0.1",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -4631,8 +4646,8 @@
     },
     "jsdom": {
       "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
-      "integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/jsdom/-/jsdom-11.11.0.tgz",
+      "integrity": "sha1-30hu+tQa7pbFmtehkOJEnH6xEQ4=",
       "dev": true,
       "requires": {
         "abab": "^1.0.4",
@@ -4755,8 +4770,8 @@
     },
     "left-pad": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/left-pad/-/left-pad-1.3.0.tgz",
+      "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
       "dev": true
     },
     "leven": {
@@ -4844,7 +4859,7 @@
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
@@ -5368,9 +5383,9 @@
       "dev": true
     },
     "nwsapi": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-      "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+      "version": "2.1.3",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/nwsapi/-/nwsapi-2.1.3.tgz",
+      "integrity": "sha1-JfOlzsJsZU9zdt9mWc34S5nflVg=",
       "dev": true
     },
     "oauth-sign": {
@@ -5604,8 +5619,8 @@
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
-      "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/parse5/-/parse5-4.0.0.tgz",
+      "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
       "dev": true
     },
     "pascalcase": {
@@ -5616,7 +5631,7 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
@@ -5687,8 +5702,8 @@
     },
     "pn": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/pn/-/pn-1.1.0.tgz",
+      "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
       "dev": true
     },
     "posix-character-classes": {
@@ -5847,8 +5862,8 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
-      "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/readdirp/-/readdirp-2.2.1.tgz",
+      "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",
@@ -5992,23 +6007,23 @@
       }
     },
     "request-promise-core": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "version": "1.1.2",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/request-promise-core/-/request-promise-core-1.1.2.tgz",
+      "integrity": "sha1-M59qq6vK/bMceZ/xWHADNjAdM0Y=",
       "dev": true,
       "requires": {
-        "lodash": "^4.13.1"
+        "lodash": "^4.17.11"
       }
     },
     "request-promise-native": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "version": "1.0.7",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/request-promise-native/-/request-promise-native-1.0.7.tgz",
+      "integrity": "sha1-pJhopiS96lBp8SUdCoNuDYmqLFk=",
       "dev": true,
       "requires": {
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "^1.1.0",
-        "tough-cookie": ">=2.3.3"
+        "request-promise-core": "1.1.2",
+        "stealthy-require": "^1.1.1",
+        "tough-cookie": "^2.3.3"
       }
     },
     "require-directory": {
@@ -6468,7 +6483,7 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
@@ -6909,7 +6924,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -7110,9 +7125,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "version": "3.2.2",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/typescript/-/typescript-3.2.2.tgz",
+      "integrity": "sha1-/oEBxGqhI/g1NSPr3PVzDCrkk+U=",
       "dev": true
     },
     "uglify-js": {
@@ -7223,9 +7238,9 @@
       }
     },
     "upath": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
-      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
+      "version": "1.1.2",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/upath/-/upath-1.1.2.tgz",
+      "integrity": "sha1-PbZYYA7a7sy+bbXmhNZ+6MKs0Gg=",
       "dev": true
     },
     "uri-js": {
@@ -7295,7 +7310,7 @@
     },
     "w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
@@ -7338,14 +7353,14 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
-      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "dev": true,
       "requires": {
         "lodash.sortby": "^4.7.0",
@@ -7576,8 +7591,8 @@
     },
     "ws": {
       "version": "4.1.0",
-      "resolved": "http://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
-      "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/ws/-/ws-4.1.0.tgz",
+      "integrity": "sha1-qXm119TaaL9U7+BAiWfDJIaacok=",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0",
@@ -7586,8 +7601,8 @@
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },
     "xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,13 +140,13 @@
     },
     "acorn": {
       "version": "5.7.3",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn/-/acorn-5.7.3.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn/-/acorn-5.7.3.tgz",
       "integrity": "sha1-Z6ojG/iBKXS4UjWpZ3Hra9B+onk=",
       "dev": true
     },
     "acorn-globals": {
       "version": "4.3.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn-globals/-/acorn-globals-4.3.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn-globals/-/acorn-globals-4.3.0.tgz",
       "integrity": "sha1-47b42jwVUqla5idXH33Wkju1QQM=",
       "dev": true,
       "requires": {
@@ -164,7 +164,7 @@
     },
     "acorn-walk": {
       "version": "6.1.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn-walk/-/acorn-walk-6.1.1.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/acorn-walk/-/acorn-walk-6.1.1.tgz",
       "integrity": "sha1-02O2b1+sXwGP+cOh57b44xDMORM=",
       "dev": true
     },
@@ -361,7 +361,7 @@
     },
     "async-limiter": {
       "version": "1.0.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/async-limiter/-/async-limiter-1.0.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
       "dev": true
     },
@@ -730,7 +730,7 @@
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
       "integrity": "sha1-YW8A+u8d9+wbW/nP4r3DFw8mx7Q=",
       "dev": true
     },
@@ -826,22 +826,20 @@
       }
     },
     "choices.js": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/choices.js/-/choices.js-4.1.3.tgz",
-      "integrity": "sha512-DWbAyJ5+1izvqszUrvSKbyZ6AP34oobbVW6s/5LF6WqTBhXhcivwYFsY3R8AIcQ09w3AVn7d0/QEHVTTWLGKEw==",
+      "version": "7.0.0",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/choices.js/-/choices.js-7.0.0.tgz",
+      "integrity": "sha1-jbT/i6r/rF4yGWDb+K65UZ9YNRw=",
       "dev": true,
       "requires": {
-        "classnames": "^2.2.5",
-        "core-js": "^2.5.6",
-        "custom-event-polyfill": "^0.3.0",
+        "classnames": "^2.2.6",
         "deepmerge": "^2.2.1",
-        "fuse.js": "^3.1.0",
+        "fuse.js": "3.4.2",
         "redux": "^3.3.1"
       }
     },
     "chokidar": {
       "version": "2.0.3",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/chokidar/-/chokidar-2.0.3.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/chokidar/-/chokidar-2.0.3.tgz",
       "integrity": "sha1-3L1PbLsqVbR5m6ioQKxSfl9LEXY=",
       "dev": true,
       "requires": {
@@ -890,8 +888,8 @@
     },
     "classnames": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha1-Q5Nb/90pHzJtrQogUwmzjQD2UM4=",
       "dev": true
     },
     "cliui": {
@@ -1101,7 +1099,7 @@
     },
     "cssstyle": {
       "version": "0.3.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/cssstyle/-/cssstyle-0.3.1.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/cssstyle/-/cssstyle-0.3.1.tgz",
       "integrity": "sha1-bam0z/G8XXFubl/o4E/LG1Ckmt8=",
       "dev": true,
       "requires": {
@@ -1117,12 +1115,6 @@
         "array-find-index": "^1.0.1"
       }
     },
-    "custom-event-polyfill": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/custom-event-polyfill/-/custom-event-polyfill-0.3.0.tgz",
-      "integrity": "sha1-mYB4Ob5i7bRGtkWDLg2A6tb6GIg=",
-      "dev": true
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1134,7 +1126,7 @@
     },
     "data-urls": {
       "version": "1.1.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/data-urls/-/data-urls-1.1.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/data-urls/-/data-urls-1.1.0.tgz",
       "integrity": "sha1-Fe4Fgrql4iu1nHcUDaj5x2lju/4=",
       "dev": true,
       "requires": {
@@ -1145,13 +1137,13 @@
       "dependencies": {
         "abab": {
           "version": "2.0.0",
-          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/abab/-/abab-2.0.0.tgz",
+          "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/abab/-/abab-2.0.0.tgz",
           "integrity": "sha1-q6CrTF7uLUx500h9hUUPsjduuw8=",
           "dev": true
         },
         "whatwg-url": {
           "version": "7.0.0",
-          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-url/-/whatwg-url-7.0.0.tgz",
+          "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-url/-/whatwg-url-7.0.0.tgz",
           "integrity": "sha1-/ekm+lSlmfOt+C3/Jan3vgLcbt0=",
           "dev": true,
           "requires": {
@@ -1191,8 +1183,8 @@
     },
     "deepmerge": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
-      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha1-XT/yKgHAD2RUBaL7wX0HeKGAEXA=",
       "dev": true
     },
     "default-require-extensions": {
@@ -1298,7 +1290,7 @@
     },
     "domexception": {
       "version": "1.0.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/domexception/-/domexception-1.0.1.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/domexception/-/domexception-1.0.1.tgz",
       "integrity": "sha1-k3RCZEymoxJh7zbj7Gd/6AVYLJA=",
       "dev": true,
       "requires": {
@@ -2310,9 +2302,9 @@
       }
     },
     "fuse.js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.3.0.tgz",
-      "integrity": "sha512-ESBRkGLWMuVkapqYCcNO1uqMg5qbCKkgb+VS6wsy17Rix0/cMS9kSOZoYkjH8Ko//pgJ/EEGu0GTjk2mjX2LGQ==",
+      "version": "3.4.2",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/fuse.js/-/fuse.js-3.4.2.tgz",
+      "integrity": "sha1-16Y4xDbs17nEwAUUeMCVlOuVYhI=",
       "dev": true
     },
     "gauge": {
@@ -2425,7 +2417,7 @@
     },
     "glob-parent": {
       "version": "3.1.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/glob-parent/-/glob-parent-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
       "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
       "dev": true,
       "requires": {
@@ -2435,7 +2427,7 @@
       "dependencies": {
         "is-glob": {
           "version": "3.1.0",
-          "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/is-glob/-/is-glob-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
@@ -2802,7 +2794,7 @@
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/is-binary-path/-/is-binary-path-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
@@ -2895,7 +2887,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
@@ -4643,7 +4635,7 @@
     },
     "jsdom": {
       "version": "11.11.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/jsdom/-/jsdom-11.11.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/jsdom/-/jsdom-11.11.0.tgz",
       "integrity": "sha1-30hu+tQa7pbFmtehkOJEnH6xEQ4=",
       "dev": true,
       "requires": {
@@ -4767,7 +4759,7 @@
     },
     "left-pad": {
       "version": "1.3.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/left-pad/-/left-pad-1.3.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha1-W4o6d2Xf4AEmHd6RVYnngvjJTR4=",
       "dev": true
     },
@@ -4826,8 +4818,8 @@
     },
     "lodash-es": {
       "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.11.tgz",
-      "integrity": "sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/lodash-es/-/lodash-es-4.17.11.tgz",
+      "integrity": "sha1-FFq0p6xcXlKjUx+08xAlWhUrS+A=",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -4856,7 +4848,7 @@
     },
     "lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
     },
@@ -5616,7 +5608,7 @@
     },
     "parse5": {
       "version": "4.0.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/parse5/-/parse5-4.0.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/parse5/-/parse5-4.0.0.tgz",
       "integrity": "sha1-bXhlbj2o14tOwLkG98CO8d/j9gg=",
       "dev": true
     },
@@ -5628,7 +5620,7 @@
     },
     "path-dirname": {
       "version": "1.0.2",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/path-dirname/-/path-dirname-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
       "dev": true
     },
@@ -5699,7 +5691,7 @@
     },
     "pn": {
       "version": "1.1.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/pn/-/pn-1.1.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/pn/-/pn-1.1.0.tgz",
       "integrity": "sha1-4vTO8OIZ9GPBeas3Rj5OHs3Muvs=",
       "dev": true
     },
@@ -5768,7 +5760,7 @@
     },
     "progress": {
       "version": "2.0.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/progress/-/progress-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
@@ -5859,7 +5851,7 @@
     },
     "readdirp": {
       "version": "2.2.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/readdirp/-/readdirp-2.2.1.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/readdirp/-/readdirp-2.2.1.tgz",
       "integrity": "sha1-DodiKjMlqjPokihcr4tOhGUppSU=",
       "dev": true,
       "requires": {
@@ -5870,7 +5862,7 @@
     },
     "rechoir": {
       "version": "0.6.2",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/rechoir/-/rechoir-0.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
@@ -5889,8 +5881,8 @@
     },
     "redux": {
       "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/redux/-/redux-3.7.2.tgz",
+      "integrity": "sha1-BrcxIyFZAdJdBlvjQusCa8HIU3s=",
       "dev": true,
       "requires": {
         "lodash": "^4.2.1",
@@ -6480,7 +6472,7 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
@@ -6594,8 +6586,8 @@
     },
     "symbol-observable": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
-      "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/symbol-observable/-/symbol-observable-1.2.0.tgz",
+      "integrity": "sha1-wiaIrtTqs83C3+rLtWFmBWCgCAQ=",
       "dev": true
     },
     "symbol-tree": {
@@ -6921,7 +6913,7 @@
     },
     "tr46": {
       "version": "1.0.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/tr46/-/tr46-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
@@ -7134,7 +7126,7 @@
     },
     "typedoc-default-themes": {
       "version": "0.5.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
       "dev": true
     },
@@ -7324,7 +7316,7 @@
     },
     "w3c-hr-time": {
       "version": "1.0.1",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
       "integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
       "dev": true,
       "requires": {
@@ -7367,13 +7359,13 @@
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha1-PUseAxLSB5h5+Cav8Y2+7KWWD78=",
       "dev": true
     },
     "whatwg-url": {
       "version": "6.5.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/whatwg-url/-/whatwg-url-6.5.0.tgz",
       "integrity": "sha1-8t8Cv/F2/WUHDfdK1cy7WhmZZag=",
       "dev": true,
       "requires": {
@@ -7605,7 +7597,7 @@
     },
     "ws": {
       "version": "4.1.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/ws/-/ws-4.1.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/ws/-/ws-4.1.0.tgz",
       "integrity": "sha1-qXm119TaaL9U7+BAiWfDJIaacok=",
       "dev": true,
       "requires": {
@@ -7615,7 +7607,7 @@
     },
     "xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://tools.adidas-group.com/artifactory/api/npm/npm-virtual/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "resolved": "http://tools.adidas-group.com/artifactory/api/npm/npm-virtual/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha1-auc+Bt5NjG5H+fsYH3jWSK1FfGo=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "choicesjs-stencil",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "choices.js": "^4.1"
   },
   "devDependencies": {
-    "@stencil/core": "0.16.0",
+    "@babel/plugin-syntax-dynamic-import": "7.2.0",
+    "@stencil/core": "0.17.0",
     "@stencil/sass": "0.1.1",
     "@stencil/utils": "0.0.5",
     "@types/jest": "21.1.8",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:coverage:unit": "npm run test:unit -- --coverage"
   },
   "peerDependencies": {
-    "choices.js": "^4.1"
+    "choices.js": "^7.0"
   },
   "devDependencies": {
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
@@ -40,7 +40,7 @@
     "@stencil/sass": "0.1.1",
     "@stencil/utils": "0.0.5",
     "@types/jest": "21.1.8",
-    "choices.js": "4.1.3",
+    "choices.js": "7.0.0",
     "copy": "0.3.2",
     "jest": "21.2.1",
     "jest-dot-reporter": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choicesjs-stencil",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Select Web Component which wraps ChoicesJS library using StencilJS",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -36,23 +36,23 @@
   },
   "devDependencies": {
     "@babel/plugin-syntax-dynamic-import": "7.2.0",
-    "@stencil/core": "0.17.0",
+    "@stencil/core": "0.18.1",
     "@stencil/sass": "0.1.1",
     "@stencil/utils": "0.0.5",
     "@types/jest": "21.1.8",
     "choices.js": "4.1.3",
     "copy": "0.3.2",
     "jest": "21.2.1",
-    "jest-dot-reporter": "1.0.3",
-    "rimraf": "2.6.2",
-    "tslint": "5.11.0",
+    "jest-dot-reporter": "1.0.7",
+    "rimraf": "2.6.3",
+    "tslint": "5.15.0",
     "tslint-config-adidas": "1.0.1",
     "tslint-eslint-rules": "5.4.0",
-    "typedoc": "0.12.0",
+    "typedoc": "0.14.2",
     "workbox-build": "3.4.1"
   },
   "optionalDependencies": {
-    "fsevents": "1.2.4"
+    "fsevents": "1.2.7"
   },
   "keywords": [
     "choicesjs",

--- a/src/components/choicesjs-stencil/choicesjs-stencil.tsx
+++ b/src/components/choicesjs-stencil/choicesjs-stencil.tsx
@@ -1,10 +1,11 @@
-import { Component, Element, Event, EventEmitter, Method, Prop } from '@stencil/core';
+import { Component, Element, Event, EventEmitter, Method, Prop, JSXElements } from '@stencil/core';
 import {
   AjaxFn,
   ClassNames,
   FuseOptions,
   IChoicesProps,
   IChoicesMethods,
+  ItemFilterFn,
   NoResultsTextFn,
   NoChoicesTextFn,
   AddItemTextFn,
@@ -14,7 +15,7 @@ import {
   OnCreateTemplates,
   UniqueItemText
 } from './interfaces';
-import { createSelectOptions, filterObject, isDefined } from './utils';
+import { getValues, filterObject, isDefined } from './utils';
 
 @Component({
   tag: 'choicesjs-stencil',
@@ -44,7 +45,7 @@ export class ChoicesJSStencil implements IChoicesProps, IChoicesMethods {
   @Prop() public searchResultLimit: number;
   @Prop() public position: 'auto' | 'top' | 'bottom';
   @Prop() public resetScrollPosition: boolean;
-  @Prop() public regexFilter: RegExp;
+  @Prop() public addItemFilterFn: ItemFilterFn;
   @Prop() public shouldSort: boolean;
   @Prop() public shouldSortItems: boolean;
   @Prop() public sortFn: SortFn;
@@ -146,13 +147,6 @@ export class ChoicesJSStencil implements IChoicesProps, IChoicesMethods {
   }
 
   @Method()
-  public async toggleDropdown() {
-    this.choice.toggleDropdown();
-
-    return this;
-  }
-
-  @Method()
   public async getValue(valueOnly?: boolean): Promise<string | Array<string>> {
     return this.choice.getValue(valueOnly);
   }
@@ -174,6 +168,13 @@ export class ChoicesJSStencil implements IChoicesProps, IChoicesMethods {
   @Method()
   public async setChoices(choices: Array<any>, value: string, label: string, replaceChoices?: boolean) {
     this.choice.setChoices(choices, value, label, replaceChoices);
+
+    return this;
+  }
+
+  @Method()
+  public async clearChoices() {
+    this.choice.clearChoices();
 
     return this;
   }
@@ -239,13 +240,13 @@ export class ChoicesJSStencil implements IChoicesProps, IChoicesMethods {
     case 'single':
       this.element =
         <select { ...attributes }>
-          { this.value ? createSelectOptions(this.value) : null }
+          { this.value ? this.createSelectOptions(this.value) : null }
         </select>;
       break;
     case 'multiple':
       this.element =
         <select multiple { ...attributes }>
-          { this.value ? createSelectOptions(this.value) : null }
+          { this.value ? this.createSelectOptions(this.value) : null }
         </select>;
       break;
     case 'text':
@@ -279,7 +280,7 @@ export class ChoicesJSStencil implements IChoicesProps, IChoicesMethods {
       searchResultLimit: this.searchResultLimit,
       position: this.position,
       resetScrollPosition: this.resetScrollPosition,
-      regexFilter: this.regexFilter,
+      addItemFilterFn: this.addItemFilterFn,
       shouldSort: this.shouldSort,
       shouldSortItems: this.shouldSortItems,
       sortFn: this.sortFn,
@@ -315,5 +316,9 @@ export class ChoicesJSStencil implements IChoicesProps, IChoicesMethods {
       this.choice.destroy();
       this.choice = null;
     }
+  }
+
+  private createSelectOptions(values: string | Array<string>): Array<JSXElements.OptionHTMLAttributes<string>> {
+    return getValues(values).map((value) => <option value={ value }>{ value }</option>);
   }
 }

--- a/src/components/choicesjs-stencil/interfaces.tsx
+++ b/src/components/choicesjs-stencil/interfaces.tsx
@@ -59,6 +59,11 @@ export type FuseOptions = {
 };
 
 /**
+ * @link https://github.com/jshjohnson/Choices#additemfilterfn
+ */
+export type ItemFilterFn = (value: string) => boolean;
+
+/**
  * @link https://github.com/jshjohnson/Choices#noresultstext
  */
 export type NoResultsTextFn = () => string;
@@ -120,7 +125,7 @@ export interface IChoicesProps {
   fuseOptions?: FuseOptions;
   position?: 'auto' | 'top' | 'bottom';
   resetScrollPosition?: boolean;
-  regexFilter?: RegExp;
+  addItemFilterFn?: ItemFilterFn;
   shouldSort?: boolean;
   shouldSortItems?: boolean;
   placeholder?: boolean | string;
@@ -149,6 +154,8 @@ export type AjaxFn = (callback) => void;
  * @link https://github.com/jshjohnson/Choices#methods
  */
 export interface IChoicesMethods {
+  highlightItem(item: Element, runEvent?: boolean);
+  unhighlightItem(item: Element);
   highlightAll();
   unhighlightAll();
   removeActiveItemsByValue(value);
@@ -156,14 +163,14 @@ export interface IChoicesMethods {
   removeHighlightedItems();
   showDropdown();
   hideDropdown();
-  toggleDropdown();
-  setChoices(choices, value, label, replaceChoices);
   getValue(valueOnly);
   setValue(args);
   setChoiceByValue(value: string | Array<string>);
+  setChoices(choices, value, label, replaceChoices);
+  clearChoices();
   clearStore();
   clearInput();
-  disable();
   enable();
+  disable();
   ajax(fn: AjaxFn);
 }

--- a/src/components/choicesjs-stencil/utils.tsx
+++ b/src/components/choicesjs-stencil/utils.tsx
@@ -30,13 +30,13 @@ export function isDefined(value: any): boolean {
 }
 
 /**
- * Create the select options.
+ * Returns the list of values.
  *
- * @param value - List of values used as value and displayed text.
- * @returns List of option elements as JSX element.
+ * @param value - Value or list of values.
+ * @returns List of values.
  */
-export function createSelectOptions(value: string | Array<string>): Array<JSX.Element> {
-  const values = [].concat(typeof value === 'string' ? (value ? value.split(',') : []) : value);
-
-  return values.map((value) => <option value={ value }>{ value }</option>);
+export function getValues(value: string | Array<string>): Array<string> {
+  return typeof value !== 'undefined'
+    ? [].concat(typeof value === 'string' ? (value ? value.split(',') : []) : value)
+    : [];
 }

--- a/src/components/choicesjs-stencil/utils.tsx
+++ b/src/components/choicesjs-stencil/utils.tsx
@@ -37,6 +37,6 @@ export function isDefined(value: any): boolean {
  */
 export function getValues(value: string | Array<string>): Array<string> {
   return typeof value !== 'undefined'
-    ? [].concat(typeof value === 'string' ? (value ? value.split(',') : []) : value)
+    ? [].concat(typeof value === 'string' ? value.split(',') : value)
     : [];
 }

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>ChoicesJS Web Component (dev)</title>
-    <script src="https://rawgit.com/jshjohnson/Choices/v4.1.3/public/assets/scripts/choices.js"></script>
+    <script src="https://rawgit.com/jshjohnson/Choices/v7.0.0/public/assets/scripts/choices.js"></script>
     <script src="/build/choicesjsstencil.js"></script>
     <style>
       * {

--- a/stencil.config.js
+++ b/stencil.config.js
@@ -15,5 +15,8 @@ exports.config = {
       indexHtml: './index.html'
     }
   ],
-  plugins: [ sass() ]
+  plugins: [ sass() ],
+  devServer: {
+    openBrowser: false
+  }
 };

--- a/test/specs/unit/components/choicesjs-stencil/utils.spec.ts
+++ b/test/specs/unit/components/choicesjs-stencil/utils.spec.ts
@@ -1,4 +1,4 @@
-import { filterObject, isDefined } from '../../../../../src/components/choicesjs-stencil/utils';
+import { filterObject, isDefined, getValues } from '../../../../../src/components/choicesjs-stencil/utils';
 
 describe('Utils', () => {
   describe('filterObject()', () => {
@@ -29,6 +29,24 @@ describe('Utils', () => {
 
     it('should return false if value is undefined', () => {
       expect(isDefined(undefined)).toBe(false);
+    });
+  });
+
+  describe('getValues()', () => {
+    it('should return an empty array if there is no values', () => {
+      expect(getValues()).toHaveLength(0);
+    });
+
+    it('should return the same array as the input if the input type is array', () => {
+      const values = [ 'v1', 'v2', 'v3' ];
+
+      expect(getValues(values)).toEqual(values);
+    });
+
+    it('should return an array with the values of a comma separated string', () => {
+      const values = 'v1,v2,v3';
+
+      expect(getValues(values)).toEqual([ 'v1', 'v2', 'v3' ]);
     });
   });
 });

--- a/test/specs/unit/components/choicesjs-stencil/utils.spec.ts
+++ b/test/specs/unit/components/choicesjs-stencil/utils.spec.ts
@@ -43,6 +43,18 @@ describe('Utils', () => {
       expect(getValues(values)).toEqual(values);
     });
 
+    it('should return an array with an empty element if it is given as input', () => {
+      const values = '';
+
+      expect(getValues(values)).toEqual([ '' ]);
+    });
+
+    it('should return an array with the value given as string', () => {
+      const values = 'v1';
+
+      expect(getValues(values)).toEqual([ 'v1' ]);
+    });
+
     it('should return an array with the values of a comma separated string', () => {
       const values = 'v1,v2,v3';
 


### PR DESCRIPTION
- Updated StencilJS core to v0.18.1.
- Updated ChoicesJS to v7.0.0.
  - `regexFilter` config has been replaced with `addItemFilterFn` function.
  - `toggleDropdown` method has been removed.
  - `clearChoices` method has been added.
- Updated example with new options.
- Updated documentation with example of framework integration.
